### PR TITLE
Parse a save file only once

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,6 +29,7 @@ import uuid
 from google_measurement_protocol import Event, report
 import imgur
 import shutil
+from savefile import savefile
 
 if sys.version_info >= (3,0):
 	unicode = str
@@ -224,13 +225,13 @@ def get_logged_in_user():
 	else:
 		return None
 
-
 def file_uploaded(inputfile):
 	memfile = io.BytesIO()
 	inputfile.save(memfile)
 	md5_info = md5(memfile)
 	try:
-		player_info = playerInfo(memfile.getvalue(), True)
+		save = savefile(memfile.getvalue(), True)
+		player_info = playerInfo(save)
 	except defusedxml.common.EntitiesForbidden:
 		error = "I don't think that's very funny"
 		return {'type':'render','target':'index.html','parameters':{"error":error}}
@@ -256,7 +257,7 @@ def file_uploaded(inputfile):
 		return {'type':'redirect','target':'display_data','parameters':{"url":dupe[0]}}
 		return redirect(url_for('display_data',url=dupe[0]))
 	else:
-		farm_info = getFarmInfo(memfile.getvalue(),True)
+		farm_info = getFarmInfo(save)
 		outcome, del_token, rowid, error = insert_info(player_info,farm_info,md5_info)
 		if outcome != False:
 			filename = os.path.join(app.config['UPLOAD_FOLDER'],outcome)

--- a/farmInfo.py
+++ b/farmInfo.py
@@ -1,5 +1,3 @@
-from defusedxml.ElementTree import parse
-from defusedxml import ElementTree
 from PIL import Image
 from collections import namedtuple
 
@@ -47,17 +45,15 @@ def checkSurrounding(tiles):
 # located on the players farm.
 # returns a dict with an array of tuples of the form: (name, x, y)
 
-def getFarmInfo(saveFileLocation, read_data=False):
+def getFarmInfo(saveFile):
     sprite = namedtuple('Sprite', ['name', 'x', 'y', 'w', 'h', 'index', 'type', 'growth', 'flipped', 'orientation'])
 
     ns = "{http://www.w3.org/2001/XMLSchema-instance}"
 
     farm = {}
 
-    if read_data is False:
-        root = parse(saveFileLocation).getroot()
-    else:
-        root = ElementTree.fromstring(saveFileLocation)
+    root = saveFile.getRoot()
+
 
     # Farm Objects
 

--- a/playerInfo.py
+++ b/playerInfo.py
@@ -1,5 +1,3 @@
-from defusedxml.ElementTree import parse
-from defusedxml import ElementTree
 import json
 
 ns = "{http://www.w3.org/2001/XMLSchema-instance}"
@@ -11,8 +9,7 @@ class player:
     def __init__(self, saveFile):
         # super(player, self).__init__()
         self.saveFile = saveFile
-        self.eTree = parse(saveFile)
-        self.root = self.eTree.getroot()
+        self.root = self.saveFile.getRoot()
 
     def getPlayerInfo(self):
         return playerInfo(self.saveFile)
@@ -100,7 +97,7 @@ def strToBool(x):
         return False
 
 
-def playerInfo(saveFileLocation,read_data=False):
+def playerInfo(saveFile):
     playerTags = ['name', 'isMale', 'farmName', 'favoriteThing', 'catPerson', 'deepestMineLevel', 'farmingLevel',
                 'miningLevel', 'combatLevel', 'foragingLevel', 'fishingLevel', 'professions', 'maxHealth', 'maxStamina',
                 'maxItems', 'money', 'totalMoneyEarned', 'millisecondsPlayed', 'friendships', 'shirt', 'hair', 'skin',
@@ -112,10 +109,7 @@ def playerInfo(saveFileLocation,read_data=False):
     npcs = ['Willy','Clint','Jodi','Harvey','Leah','Wizard','Jas','Abigail','Maru','Elliott','Caroline','Pam','Dwarf',
             'Shane','Demetrius','Alex','Gus','Vincent','Sebastian','Robin','Sam','Lewis','Marnie','Penny','Haley','Pierre',
             'Evelyn','Linus','George','Emily','Kent','Krobus','Sandy']
-    if read_data == False:
-        root = parse(saveFileLocation).getroot()
-    else:
-        root = ElementTree.fromstring(saveFileLocation)
+    root = saveFile.getRoot()
 
     player = root.find("player")
     info = {}

--- a/reprocessEntry.py
+++ b/reprocessEntry.py
@@ -6,7 +6,6 @@ import json
 import hashlib
 from imageDrone import process_queue
 from createdb import database_structure_dict, database_fields
-import defusedxml
 import io
 from xml.etree.ElementTree import ParseError
 from app import connect_db, md5, app

--- a/savefile.py
+++ b/savefile.py
@@ -1,0 +1,16 @@
+from defusedxml.ElementTree import parse
+from defusedxml import ElementTree
+
+class savefile:
+    """Hold onto the parse save game"""
+    def __init__(self, saveFile, read_data=False):
+        self.saveFile = saveFile
+        if read_data == False:
+            root = parse(saveFile).getroot()
+        else:
+            root = ElementTree.fromstring(saveFile)
+
+        self.root = root
+
+    def getRoot(self):
+        return self.root


### PR DESCRIPTION
Instead of parsing the save file multiple times, pass around a savefile class which just parses it once. Loading the xml file is the slowest part of the upload process right now.