### PR TITLE
RFC - Add some startup development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,46 @@ As per flask-mail docs and your email server
 
 ## Initialization
 
-Once the config file has been written, run createadmin.py and createdb.py and follow the prompts to create the database structure.
+Install prerequisites using a tool like [pip](https://pypi.org/project/pip/) (`pip3` if you're using Python 3):
+
+```bash
+pip install flask
+pip install psycopg2
+pip install Flask-Babel
+pip install Flask-reCaptcha
+pip install flask-bcrypt
+pip install Flask-Mail
+pip install google-measurement-protocol
+```
+
+You need PostgreSQL installed and running. Then create a database:
+
+```bash
+createdb sdv_summary_development
+```
+
+To create a config file for SDV-Summary:
+
+```bash
+cp sdv/config.py.sample sdv/config.py
+```
+
+Modify sdv/config.py to specify the user name and password for the PostgreSQL database you created.
+
+Once the config file has been written, run createadmin.py and createdb.py and follow the prompts to create the database structure:
+
+```bash
+SDV_APP_SETTINGS=development python sdv/createadmin.py
+SDV_APP_SETTINGS=development python sdv/createdb.py
+```
 
 To run, the templating engine jinja2 needs `sdv\templates\analytics.html` to exist.
+
+Run the app using Flask:
+
+```bash
+FLASK_APP=runserver.py flask run
+```
 
 Assets for image generation go in `sdv\assets\[subfolder]`. Assets used as-is go in `sdv\static\assets\[subfolder]`.
 

--- a/sdv/config.py.sample
+++ b/sdv/config.py.sample
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+class DevelopmentConfig():
+  DEBUG = True
+  USE_SQLITE = False
+  DB_NAME = 'sdv_summary_development'
+  DB_USER = ''
+  DB_PASSWORD = ''
+
+config = {
+  'development': DevelopmentConfig
+}


### PR DESCRIPTION
Hi @Sketchy502! I got a bit further following your instructions in https://github.com/Sketchy502/SDV-Summary/issues/46#issuecomment-451305830 but I hit another error when I try to run the app:

```
% FLASK_APP=runserver.py flask run
 * Serving Flask app "runserver.py"
 * Environment: production
   WARNING: Do not use the development server in a production environment.
   Use a production WSGI server instead.
 * Debug mode: off
Usage: flask run [OPTIONS]

Error: While importing "runserver", an ImportError was raised:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/flask/cli.py", line 235, in locate_app
    __import__(module_name)
  File "/Users/cheshire137/code/Sketchy502/SDV-Summary/runserver.py", line 13, in <module>
    from sdv import app
  File "/Users/cheshire137/code/Sketchy502/SDV-Summary/sdv/__init__.py", line 12, in <module>
    from google_measurement_protocol import Event, report
ImportError: cannot import name 'Event'
```

Could you tell me if the instructions I've added to README.md are accurate? Doing those steps was what let me get to this point ☝️ but since the app isn't running yet, I may have done something wrong! Thanks for your help.