### PR TITLE
Fix display issue with a navigation tab border image

### DIFF
--- a/sdv/static/css/style.css
+++ b/sdv/static/css/style.css
@@ -735,12 +735,12 @@ p.cc_message {
 
     border-radius: 30px;
     border-style: solid;
-    border-width: 21px 21px 21px 21px;
+    border-width: 21px;
 
-    -moz-border-image: url(textBox.png) 30 30 30 30 stretch;
-    -webkit-border-image: url(textBox.png) 30 30 30 30 stretch;
-    -o-border-image: url(textBox.png) 30 30 30 30 stretch;
-    border-image: url(textBox.png) 30 30 30 30 fill stretch;
+    -moz-border-image: url(textBox.png) 30 fill repeat;
+    -webkit-border-image: url(textBox.png) 30 fill repeat;
+    -o-border-image: url(textBox.png) 30 fill repeat;
+    border-image: url(textBox.png) 30 fill repeat;
 
     transition: margin-left 300ms cubic-bezier(0.4, 0.0, 0.2, 1);
 }


### PR DESCRIPTION
If that's the right place to change CSS this should fix display issue with a navigation tab border image.

Before (Chrome):
![image](https://user-images.githubusercontent.com/1931904/104454221-965cb900-55b6-11eb-9cbd-72d6a6d49237.png)

After (Chrome):
![image](https://user-images.githubusercontent.com/1931904/104454264-a8d6f280-55b6-11eb-87fa-96b4ac5b47f2.png)

Solution:
Change border-image-repeat CSS property to repeat
Additionally:
+ Set the same values for all prefixes
+ Clean a little bit

```
* Edited in github.com Web-UI.
* Tested in the Chrome browser developer console.
```